### PR TITLE
- 优化代币购买，现在默认代币购买均为关闭 #140

### DIFF
--- a/Honkai_Star_Rail.py
+++ b/Honkai_Star_Rail.py
@@ -157,6 +157,7 @@ def main():
         main()
 
 def main_start():
+    cfg.ensure_config_complete()
     if cfg.config_issubset():
         if not cfg.read_json_file(cfg.CONFIG_FILE_NAME, False).get('start'):
             cfg.modify_json_file(cfg.CONFIG_FILE_NAME, "start", True)

--- a/map/default/map_3-1_0.json
+++ b/map/default/map_3-1_0.json
@@ -3,6 +3,9 @@
     "author": "lrwy",
     "start": [
         {
+            "need_allow_map_buy": 1
+        },
+        {
             "check": 1
 		},
         {

--- a/map/default/map_3-1_01.json
+++ b/map/default/map_3-1_01.json
@@ -3,6 +3,9 @@
     "author": "lrwy",
     "start": [
         {
+            "need_allow_map_buy": 1
+        },
+        {
             "check": 1
         },
         {

--- a/map/default/map_4-1_0.json
+++ b/map/default/map_4-1_0.json
@@ -3,11 +3,17 @@
     "author": "lrwy",
     "start": [
         {
+          "need_allow_map_buy": 1
+        },
+        {
             "check": 1
 		},
         {
             "map": 1
 		},
+        {
+            "picture\\map_4-2_point_3.png": 1.5
+        },
         {
             "picture\\orientation_1.png": 1.5
         },

--- a/map/default/map_4-1_01.json
+++ b/map/default/map_4-1_01.json
@@ -3,6 +3,9 @@
     "author": "lrwy",
     "start": [
         {
+            "need_allow_map_buy": 1
+        },
+        {
             "check": 1
         },
         {

--- a/map/default/map_4-1_1.json
+++ b/map/default/map_4-1_1.json
@@ -6,6 +6,9 @@
             "map": 1
         },
         {
+          "picture\\map_4-2_point_3.png": 1.5
+        },
+        {
            "picture\\orientation_1.png": 1.5
         },
         {

--- a/map/technique/map_1-1_1.json
+++ b/map/technique/map_1-1_1.json
@@ -6,6 +6,9 @@
             "map": 1
         },
         {
+            "picture\\map_4-2_point_3.png": 1.5
+        },
+        {
             "picture\\orientation_1.png": 1.5
         },
         {

--- a/map/technique/map_2-1_1.json
+++ b/map/technique/map_2-1_1.json
@@ -6,6 +6,9 @@
             "map": 1
         },
         {
+          "picture\\map_4-2_point_3.png": 1.5
+        },
+        {
             "picture\\orientation_1.png": 1.5
         },
         {

--- a/map/technique/map_3-1_0.json
+++ b/map/technique/map_3-1_0.json
@@ -3,6 +3,9 @@
     "author": "lrwy",
     "start": [
         {
+            "need_allow_map_buy": 1
+        },
+        {
             "check": 1
 		},
         {

--- a/map/technique/map_3-1_01.json
+++ b/map/technique/map_3-1_01.json
@@ -3,6 +3,9 @@
     "author": "lrwy",
     "start": [
         {
+            "need_allow_map_buy": 1
+        },
+        {
             "check": 1
         },
         {

--- a/map/technique/map_3-1_1.json
+++ b/map/technique/map_3-1_1.json
@@ -6,6 +6,9 @@
             "map": 1
         },
         {
+            "picture\\map_4-2_point_3.png": 1.5
+        },
+        {
             "picture\\orientation_1.png": 1.5
         },
         {

--- a/map/technique/map_4-1_0.json
+++ b/map/technique/map_4-1_0.json
@@ -3,11 +3,17 @@
     "author": "lrwy",
     "start": [
         {
+        "need_allow_map_buy": 1
+        },
+        {
             "check": 1
 		},
         {
             "map": 1
 		},
+        {
+            "picture\\map_4-2_point_3.png": 1.5
+        },
         {
             "picture\\orientation_1.png": 1.5
         },

--- a/map/technique/map_4-1_01.json
+++ b/map/technique/map_4-1_01.json
@@ -3,6 +3,9 @@
     "author": "lrwy",
     "start": [
         {
+            "need_allow_map_buy": 1
+        },
+        {
             "check": 1
         },
         {

--- a/map/technique/map_4-1_1.json
+++ b/map/technique/map_4-1_1.json
@@ -6,6 +6,9 @@
             "map": 1
         },
         {
+          "picture\\map_4-2_point_3.png": 1.5
+        },
+        {
            "picture\\orientation_1.png": 1.5
         },
         {

--- a/utils/config.py
+++ b/utils/config.py
@@ -115,7 +115,8 @@ class ConfigurationManager:
             "map_version": "default",
             "main_map": "1",
             "allow_run_again": False,
-            "allow_run_next_day": False
+            "allow_run_next_day": False,
+            "allow_map_buy": False
         }
         
         

--- a/utils/map.py
+++ b/utils/map.py
@@ -232,6 +232,14 @@ class Map:
                             log.info(f"{today_weekday_str}，非周二五日，跳过")
                             jump_this_map = True
                             break
+                    elif key == "need_allow_map_buy":
+                        if self.cfg.read_json_file(self.cfg.CONFIG_FILE_NAME, False).get('allow_map_buy', False):
+                            jump_this_map = False
+                            continue
+                        else:
+                            log.info(f" config.json 中的 allow_map_buy 为 False ，跳过该图{map_data['name']}，如果需要开启购买请改为 True 并且【自行确保】能够正常购买对应物品")
+                            jump_this_map = True
+                            break
                     elif key == "normal_run":
                         normal_run = True  # 此地图json将会被强制设定为禁止疾跑
                         continue


### PR DESCRIPTION
- 优化代币购买，现在默认代币购买均为关闭，需要开启请【自行确认】能够正常购买代币，开关在config.json的allow_map_buy，改为True开启 #140
- 优化写入配置逻辑，避免重复询问“缺少必要的配置”